### PR TITLE
Implement effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,26 +122,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -274,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "log"
@@ -359,12 +357,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "pico-args"
@@ -550,9 +542,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "svgfilters"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +497,7 @@ dependencies = [
  "easer",
  "glam",
  "image",
+ "itertools",
  "rayon",
  "resvg",
  "rusvid_plane",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "grid"
+version = "0.1.0"
+dependencies = [
+ "rusvid_lib",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ name = "rusvid_plane"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "image",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,8 +491,16 @@ dependencies = [
  "image",
  "rayon",
  "resvg",
+ "rusvid_plane",
  "tiny-skia",
  "usvg",
+]
+
+[[package]]
+name = "rusvid_plane"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "examples/layers",
     "examples/simple_animation",
     "examples/read_svg_file",
+    "examples/grid",
     "rusvid_lib",
     "rusvid_cli",
     "crates/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = [
     "examples/read_svg_file",
     "rusvid_lib",
     "rusvid_cli",
+    "crates/*",
 ]

--- a/crates/plane/Cargo.toml
+++ b/crates/plane/Cargo.toml
@@ -12,3 +12,4 @@ image = { version = "0.24.4", default-features = false, optional = true }
 [features]
 default = ["rgba_image"]
 rgba_image = ["dep:image"]
+unsafe = []

--- a/crates/plane/Cargo.toml
+++ b/crates/plane/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.65"
+image = { version = "0.24.4", default-features = false, optional = true }
+
+[features]
+default = ["rgba_image"]
+rgba_image = ["dep:image"]

--- a/crates/plane/Cargo.toml
+++ b/crates/plane/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rusvid_plane"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.65"

--- a/crates/plane/src/lib.rs
+++ b/crates/plane/src/lib.rs
@@ -49,7 +49,7 @@ impl Plane {
         let height = image.height() as SIZE;
 
         let mut plane = Plane::new(width, height)?;
-        let data = plane.get_pixels_mut();
+        let data = plane.pixels_mut();
 
         assert_eq!(data.len() * 4, pixels.len());
 
@@ -76,7 +76,7 @@ impl Plane {
 
     /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
     #[inline]
-    pub fn get_pixel(&self, x: SIZE, y: SIZE) -> Option<&Pixel> {
+    pub fn pixel(&self, x: SIZE, y: SIZE) -> Option<&Pixel> {
         if x > self.width {
             return None;
         }
@@ -89,7 +89,8 @@ impl Plane {
 
     /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
     #[inline]
-    pub fn get_pixel_unchecked(&self, x: SIZE, y: SIZE) -> &Pixel {
+    #[cfg(feature = "unsafe")]
+    pub fn pixel_unchecked(&self, x: SIZE, y: SIZE) -> &Pixel {
         unsafe {
             self.data
                 .get_unchecked(self.position_to_index(x, y) as usize)
@@ -98,7 +99,7 @@ impl Plane {
 
     /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
     #[inline]
-    pub fn get_pixel_mut(&mut self, x: SIZE, y: SIZE) -> Option<&mut Pixel> {
+    pub fn pixel_mut(&mut self, x: SIZE, y: SIZE) -> Option<&mut Pixel> {
         if x > self.width {
             return None;
         }
@@ -111,17 +112,18 @@ impl Plane {
 
     /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
     #[inline]
-    pub fn get_pixel_unchecked_mut(&mut self, x: SIZE, y: SIZE) -> &Pixel {
+    #[cfg(feature = "unsafe")]
+    pub fn pixel_unchecked_mut(&mut self, x: SIZE, y: SIZE) -> &Pixel {
         unsafe { self.data.get_unchecked_mut((y + self.height * x) as usize) }
     }
 
     #[inline]
-    pub fn get_pixels(&self) -> &[Pixel] {
+    pub fn pixels(&self) -> &[Pixel] {
         self.data.as_slice()
     }
 
     #[inline]
-    pub fn get_pixels_mut(&mut self) -> &mut [Pixel] {
+    pub fn pixels_mut(&mut self) -> &mut [Pixel] {
         self.data.as_mut_slice()
     }
 }
@@ -156,22 +158,25 @@ mod tests {
             .unwrap();
 
             let pixel: Pixel = [255, 0, 0, 255];
-            assert_eq!(plane.get_pixel(0, 0).unwrap(), &pixel);
+            assert_eq!(plane.pixel(0, 0).unwrap(), &pixel);
             let pixel: Pixel = [0, 255, 0, 255];
-            assert_eq!(plane.get_pixel(1, 0).unwrap(), &pixel);
+            assert_eq!(plane.pixel(1, 0).unwrap(), &pixel);
             let pixel: Pixel = [0, 0, 255, 255];
-            assert_eq!(plane.get_pixel(0, 1).unwrap(), &pixel);
+            assert_eq!(plane.pixel(0, 1).unwrap(), &pixel);
             let pixel: Pixel = [255, 255, 255, 255];
-            assert_eq!(plane.get_pixel(1, 1).unwrap(), &pixel);
+            assert_eq!(plane.pixel(1, 1).unwrap(), &pixel);
 
-            let pixel: Pixel = [255, 0, 0, 255];
-            assert_eq!(plane.get_pixel_unchecked(0, 0), &pixel);
-            let pixel: Pixel = [0, 255, 0, 255];
-            assert_eq!(plane.get_pixel_unchecked(1, 0), &pixel);
-            let pixel: Pixel = [0, 0, 255, 255];
-            assert_eq!(plane.get_pixel_unchecked(0, 1), &pixel);
-            let pixel: Pixel = [255, 255, 255, 255];
-            assert_eq!(plane.get_pixel_unchecked(1, 1), &pixel);
+            #[cfg(feature = "unsafe")]
+            let _ = {
+                let pixel: Pixel = [255, 0, 0, 255];
+                assert_eq!(plane.pixel_unchecked(0, 0), &pixel);
+                let pixel: Pixel = [0, 255, 0, 255];
+                assert_eq!(plane.pixel_unchecked(1, 0), &pixel);
+                let pixel: Pixel = [0, 0, 255, 255];
+                assert_eq!(plane.pixel_unchecked(0, 1), &pixel);
+                let pixel: Pixel = [255, 255, 255, 255];
+                assert_eq!(plane.pixel_unchecked(1, 1), &pixel);
+            };
         }
     }
 }

--- a/crates/plane/src/lib.rs
+++ b/crates/plane/src/lib.rs
@@ -1,0 +1,149 @@
+use anyhow::{bail, Result};
+
+pub type Pixel = [u8; 4];
+
+pub type SIZE = u32;
+
+#[derive(Debug)]
+pub struct Plane {
+    pub(crate) width: SIZE,
+    pub(crate) height: SIZE,
+    pub(crate) data: Vec<Pixel>,
+}
+
+impl Plane {
+    pub fn new(width: SIZE, height: SIZE) -> Result<Self> {
+        if width == 0 {
+            bail!("Width must be greater 0");
+        }
+        if height == 0 {
+            bail!("Height must be greater 0");
+        }
+
+        Ok(Plane {
+            width,
+            height,
+            data: Vec::with_capacity((width * height) as usize),
+        })
+    }
+
+    pub fn from_data(width: SIZE, height: SIZE, data: Vec<Pixel>) -> Result<Self> {
+        let mut plane = Self::new(width, height)?;
+
+        if plane.width * plane.height != data.len() as SIZE {
+            bail!("Data hasn't the right capacity");
+        }
+
+        plane.data = data;
+
+        Ok(plane)
+    }
+
+    // TODO transform into an macro, so that unsafe can use it
+    #[doc(hidden)]
+    #[inline(always)]
+    fn position_to_index(&self, x: SIZE, y: SIZE) -> SIZE {
+        x + self.height * y
+    }
+
+    /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
+    #[inline]
+    pub fn get_pixel(&self, x: SIZE, y: SIZE) -> Option<&Pixel> {
+        if x > self.width {
+            return None;
+        }
+        if y > self.height {
+            return None;
+        }
+
+        self.data.get(self.position_to_index(x, y) as usize)
+    }
+
+    /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
+    #[inline]
+    pub fn get_pixel_unchecked(&self, x: SIZE, y: SIZE) -> &Pixel {
+        unsafe {
+            self.data
+                .get_unchecked(self.position_to_index(x, y) as usize)
+        }
+    }
+
+    /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
+    #[inline]
+    pub fn get_pixel_mut(&mut self, x: SIZE, y: SIZE) -> Option<&mut Pixel> {
+        if x > self.width {
+            return None;
+        }
+        if y > self.height {
+            return None;
+        }
+
+        self.data.get_mut((y + self.height * x) as usize)
+    }
+
+    /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
+    #[inline]
+    pub fn get_pixel_unchecked_mut(&mut self, x: SIZE, y: SIZE) -> &Pixel {
+        unsafe { self.data.get_unchecked_mut((y + self.height * x) as usize) }
+    }
+
+    #[inline]
+    pub fn get_pixels(&self) -> &Vec<Pixel> {
+        &self.data
+    }
+
+    #[inline]
+    pub fn get_pixels_mut(&mut self) -> &mut Vec<Pixel> {
+        &mut self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod new {
+        use crate::Plane;
+
+        #[test]
+        fn just_works() {
+            let _ = Plane::new(100, 100).unwrap();
+            assert!(true);
+        }
+    }
+
+    mod get_pixel {
+        use crate::{Pixel, Plane};
+
+        #[test]
+        fn just_works() {
+            let plane = Plane::from_data(
+                2,
+                2,
+                vec![
+                    [255, 0, 0, 255],
+                    [0, 255, 0, 255],
+                    [0, 0, 255, 255],
+                    [255, 255, 255, 255],
+                ],
+            )
+            .unwrap();
+
+            let pixel: Pixel = [255, 0, 0, 255];
+            assert_eq!(plane.get_pixel(0, 0).unwrap(), &pixel);
+            let pixel: Pixel = [0, 255, 0, 255];
+            assert_eq!(plane.get_pixel(1, 0).unwrap(), &pixel);
+            let pixel: Pixel = [0, 0, 255, 255];
+            assert_eq!(plane.get_pixel(0, 1).unwrap(), &pixel);
+            let pixel: Pixel = [255, 255, 255, 255];
+            assert_eq!(plane.get_pixel(1, 1).unwrap(), &pixel);
+
+            let pixel: Pixel = [255, 0, 0, 255];
+            assert_eq!(plane.get_pixel_unchecked(0, 0), &pixel);
+            let pixel: Pixel = [0, 255, 0, 255];
+            assert_eq!(plane.get_pixel_unchecked(1, 0), &pixel);
+            let pixel: Pixel = [0, 0, 255, 255];
+            assert_eq!(plane.get_pixel_unchecked(0, 1), &pixel);
+            let pixel: Pixel = [255, 255, 255, 255];
+            assert_eq!(plane.get_pixel_unchecked(1, 1), &pixel);
+        }
+    }
+}

--- a/crates/plane/src/lib.rs
+++ b/crates/plane/src/lib.rs
@@ -13,6 +13,13 @@ pub struct Plane {
     pub(crate) data: Vec<Pixel>,
 }
 
+#[doc(hidden)]
+macro_rules! position_to_index {
+    ($x:expr, $y:expr, $height:expr) => {
+        ($x + $height * $y) as usize
+    };
+}
+
 impl Plane {
     pub fn new(width: SIZE, height: SIZE) -> Result<Self> {
         if width == 0 {
@@ -67,13 +74,6 @@ impl Plane {
         Ok(plane)
     }
 
-    // TODO replace with a macro, so that unsafe can use it
-    #[doc(hidden)]
-    #[inline(always)]
-    fn position_to_index(&self, x: SIZE, y: SIZE) -> SIZE {
-        x + self.height * y
-    }
-
     /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
     #[inline]
     pub fn pixel(&self, x: SIZE, y: SIZE) -> Option<&Pixel> {
@@ -84,7 +84,7 @@ impl Plane {
             return None;
         }
 
-        self.data.get(self.position_to_index(x, y) as usize)
+        self.data.get(position_to_index!(x, y, self.height))
     }
 
     /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
@@ -93,7 +93,7 @@ impl Plane {
     pub fn pixel_unchecked(&self, x: SIZE, y: SIZE) -> &Pixel {
         unsafe {
             self.data
-                .get_unchecked(self.position_to_index(x, y) as usize)
+                .get_unchecked(position_to_index!(x, y, self.height))
         }
     }
 
@@ -107,14 +107,14 @@ impl Plane {
             return None;
         }
 
-        self.data.get_mut((y + self.height * x) as usize)
+        self.data.get_mut(position_to_index!(x, y, self.height))
     }
 
     /// Coordinate system: <https://py.processing.org/tutorials/drawing/>
     #[inline]
     #[cfg(feature = "unsafe")]
     pub fn pixel_unchecked_mut(&mut self, x: SIZE, y: SIZE) -> &Pixel {
-        unsafe { self.data.get_unchecked_mut((y + self.height * x) as usize) }
+        unsafe { self.data.get_unchecked_mut(position_to_index!(x, y, self.height)) }
     }
 
     #[inline]

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ List (ordered by complexity):
 - `layers`: composition with two layers and per layer one path
 - `simple_animation`: composition with simple animation on rectangle
 - `read_svg_file`: composition with layer from `.svg`-file
-- `grid`: calculate a grid of squares with an animated background
+- `grid`: calculate a grid made out of squares with an animated background
 
 ### black_video
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,33 +6,40 @@ List (ordered by complexity):
 - `layers`: composition with two layers and per layer one path
 - `simple_animation`: composition with simple animation on rectangle
 - `read_svg_file`: composition with layer from `.svg`-file
+- `grid`: calculate a grid of squares with an animated background
 
 ### black_video
 
 Command: `cargo run -r -p black_video`
 
-<img src="/examples/videos/black_video.gif" width="250" />
+<img src="/examples/videos/black_video.gif" width="500" />
 
 ### simple_path
 
 Command: `cargo run -r -p simple_path`
 
-<img src="/examples/videos/simple_path.gif" width="250" />
+<img src="/examples/videos/simple_path.gif" width="500" />
 
 ### layers
 
 Command: `cargo run -r -p layers`
 
-<img src="/examples/videos/layers.gif" width="250" />
+<img src="/examples/videos/layers.gif" width="500" />
 
 ### simple_animation
 
 Command: `cargo run -r -p simple_animation`
 
-<img src="/examples/videos/simple_animation.gif" width="250" />
+<img src="/examples/videos/simple_animation.gif" width="500" />
 
 ### read_svg_file
 
 Command: `cargo run -r -p read_svg_file`
 
-<img src="/examples/videos/read_svg_file.gif" width="250" />
+<img src="/examples/videos/read_svg_file.gif" width="500" />
+
+### grid
+
+Command: `cargo run -r -p grid`
+
+<img src="/examples/videos/grid.gif" width="500" />

--- a/examples/grid/Cargo.toml
+++ b/examples/grid/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "grid"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rusvid_lib = { path = "../../rusvid_lib" }

--- a/examples/grid/src/main.rs
+++ b/examples/grid/src/main.rs
@@ -69,7 +69,7 @@ fn main() {
         .unwrap();
 
     background_layer.add_animation(PositionAnimation::new(
-        "bg_obj".to_string(),
+        "bg_obj",
         Linear::new(0, frames, start_pos, Point::ZERO).unwrap(),
     ));
 

--- a/examples/grid/src/main.rs
+++ b/examples/grid/src/main.rs
@@ -73,8 +73,6 @@ fn main() {
         Linear::new(0, frames, start_pos, Point::ZERO).unwrap(),
     ));
 
-    // drop(background_layer);
-
     let grid_layer = composition.create_layer().unwrap();
 
     let grid_size = Point::new(32.0, 18.0);

--- a/examples/grid/src/main.rs
+++ b/examples/grid/src/main.rs
@@ -1,0 +1,106 @@
+use std::rc::Rc;
+
+use rusvid_lib::animation::prelude::*;
+use rusvid_lib::figures::prelude::*;
+use rusvid_lib::prelude::*;
+use rusvid_lib::usvg::{
+    BaseGradient, Color, Fill, LinearGradient, NodeKind, Opacity, Paint, Path, SpreadMethod, Stop,
+    StopOffset, Transform, Units,
+};
+
+fn main() {
+    let resolution = Resolution::FHD;
+
+    let mut composition = Composition::builder()
+        .resolution(resolution)
+        .framerate(30)
+        .duration(5)
+        .build();
+
+    let frames = composition.frames();
+
+    let background_layer = composition.create_layer().unwrap();
+
+    background_layer
+        .add_to_defs(NodeKind::LinearGradient(LinearGradient {
+            id: "bg".into(),
+            x1: 0.0,
+            y1: 0.0,
+            x2: 1.0,
+            y2: 0.0,
+            base: BaseGradient {
+                units: Units::ObjectBoundingBox,
+                transform: Transform::new_rotate(35.0),
+                spread_method: SpreadMethod::Pad,
+                stops: vec![
+                    Stop {
+                        offset: StopOffset::new(0.0),
+                        color: Color::new_rgb(0, 215, 255),
+                        opacity: Opacity::new(1.0),
+                    },
+                    Stop {
+                        offset: StopOffset::new(0.5),
+                        color: Color::new_rgb(9, 9, 121),
+                        opacity: Opacity::new(1.0),
+                    },
+                    Stop {
+                        offset: StopOffset::new(1.0),
+                        color: Color::new_rgb(0, 215, 255),
+                        opacity: Opacity::new(1.0),
+                    },
+                ],
+            },
+        }))
+        .unwrap();
+
+    let start_pos = resolution.as_point() * Point::NEG_ONE;
+    background_layer
+        .add_to_root(NodeKind::Path(Path {
+            id: "bg_obj".to_string(),
+            fill: background_layer.fill_with_link("bg"),
+            data: Rc::new(rect(
+                start_pos.x,
+                start_pos.y,
+                resolution.as_point().x * 2.0,
+                resolution.as_point().y * 2.0,
+            )),
+            ..Path::default()
+        }))
+        .unwrap();
+
+    background_layer.add_animation(PositionAnimation::new(
+        "bg_obj".to_string(),
+        Linear::new(0, frames, start_pos, Point::ZERO).unwrap(),
+    ));
+
+    // drop(background_layer);
+
+    let grid_layer = composition.create_layer().unwrap();
+
+    let grid_size = Point::new(32.0, 18.0);
+    let margin = Point::new(5.0, 5.0);
+    let rect_size = (resolution.as_point() - (margin * (grid_size + Point::ONE))) / grid_size;
+
+    for x in 0..(grid_size.x as usize) {
+        for y in 0..(grid_size.y as usize) {
+            let coordinates_as_point = Point::new(x as f64, y as f64);
+            let extra_margin = margin * (coordinates_as_point + Point::ONE);
+            let rect_pos = coordinates_as_point * rect_size + extra_margin;
+
+            grid_layer
+                .add_to_root(NodeKind::Path(Path {
+                    id: "rect".to_string(),
+                    fill: Some(Fill {
+                        paint: Paint::Color(Color::new_rgb(0, 0, 0)),
+                        ..Fill::default()
+                    }),
+                    data: Rc::new(rect(rect_pos.x, rect_pos.y, rect_size.x, rect_size.y)),
+                    ..Path::default()
+                }))
+                .unwrap();
+        }
+    }
+
+    let mut renderer = FfmpegRenderer::new("grid.mp4", "./out", FrameImageFormat::Png);
+    renderer.render(composition).unwrap()
+}

--- a/examples/simple_animation/src/main.rs
+++ b/examples/simple_animation/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         .unwrap();
 
     layer.add_animation(PositionAnimation::new(
-        "rect".to_string(),
+        "rect",
         Cubic::new_with_ease_type(
             0,
             frames,

--- a/rusvid_cli/src/main.rs
+++ b/rusvid_cli/src/main.rs
@@ -1,12 +1,11 @@
-use std::path::PathBuf;
 use std::rc::Rc;
 
 use rusvid_lib::animation::prelude::*;
 use rusvid_lib::figures::prelude::*;
 use rusvid_lib::prelude::*;
 use rusvid_lib::usvg::{
-    BaseGradient, LinearGradient, NodeKind, Opacity, Paint, Path, SpreadMethod, Stop, StopOffset,
-    Stroke, StrokeWidth, Transform, Units,
+    BaseGradient, Color, LinearGradient, NodeKind, Opacity, Paint, Path, SpreadMethod, Stop,
+    StopOffset, Stroke, StrokeWidth, Transform, Units,
 };
 use rusvid_lib::utils::color_from_hex;
 
@@ -17,7 +16,14 @@ fn main() {
         .resolution(resolution)
         .framerate(24)
         .duration(5)
-        .add_effect(ColorPaletteEffect::new(vec![[0, 0, 0, 255], [255; 4]]))
+        // .add_effect(PixelateEffect::new(15, 15))
+        // .add_effect(GrayscaleEffect::new())
+        // .add_effect(ColorPaletteEffect::new(vec![
+        //     [10, 56, 120, 255],
+        //     [100, 100, 0, 255],
+        //     [100, 10, 100, 255],
+        //     [90, 12, 30, 255],
+        // ]))
         .build();
 
     let layer = composition.create_layer().unwrap(); // Layer::new(composition.resolution());
@@ -63,7 +69,7 @@ fn main() {
         }))
         .unwrap();
     layer.add_animation(PositionAnimation::new(
-        "circle".to_string(),
+        "circle",
         Elastic::new_with_ease_type(
             0,
             90,
@@ -74,7 +80,6 @@ fn main() {
         .unwrap(),
     ));
 
-    /*
     let layer = composition.create_layer().unwrap();
     layer
         .add_to_defs(NodeKind::LinearGradient(LinearGradient {
@@ -135,18 +140,14 @@ fn main() {
         }))
         .unwrap();
     layer.add_animation(PositionAnimation::new(
-        "rect".to_string(),
+        "rect",
         Linear::new(0, 200, pixel_position, (1250.0, 500.0).into()).unwrap(),
     ));
     layer.add_animation(PositionAnimation::new(
-        "rect".to_string(),
+        "rect",
         Linear::new(220, 290, (1250.0, 500.0).into(), (0.0, 0.0).into()).unwrap(),
     ));
-     */
 
-    let out_path = PathBuf::from("out.mp4");
-    let tmp_path = PathBuf::from("./out");
-
-    let mut renderer = FfmpegRenderer::new(out_path, tmp_path, FrameImageFormat::Png);
+    let mut renderer = FfmpegRenderer::new("out.mp4", "./out", FrameImageFormat::Png);
     renderer.render(composition).unwrap()
 }

--- a/rusvid_cli/src/main.rs
+++ b/rusvid_cli/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
         .resolution(resolution)
         .framerate(24)
         .duration(5)
-        .add_effect(ColorPaletteEffect::new(vec![[0,0,0,255], [255; 4]]))
+        .add_effect(ColorPaletteEffect::new(vec![[0, 0, 0, 255], [255; 4]]))
         .build();
 
     let layer = composition.create_layer().unwrap(); // Layer::new(composition.resolution());

--- a/rusvid_cli/src/main.rs
+++ b/rusvid_cli/src/main.rs
@@ -5,8 +5,8 @@ use rusvid_lib::animation::prelude::*;
 use rusvid_lib::figures::prelude::*;
 use rusvid_lib::prelude::*;
 use rusvid_lib::usvg::{
-    BaseGradient, Color, LinearGradient, NodeKind, Opacity, Paint, Path, SpreadMethod, Stop,
-    StopOffset, Stroke, StrokeWidth, Transform, Units,
+    BaseGradient, LinearGradient, NodeKind, Opacity, Paint, Path, SpreadMethod, Stop, StopOffset,
+    Stroke, StrokeWidth, Transform, Units,
 };
 use rusvid_lib::utils::color_from_hex;
 
@@ -15,8 +15,9 @@ fn main() {
 
     let mut composition = Composition::builder()
         .resolution(resolution)
-        .framerate(60)
+        .framerate(24)
         .duration(5)
+        .add_effect(ColorPaletteEffect::new(vec![[0,0,0,255], [255; 4]]))
         .build();
 
     let layer = composition.create_layer().unwrap(); // Layer::new(composition.resolution());
@@ -53,7 +54,7 @@ fn main() {
             id: "circle".to_string(),
             stroke: Some(Stroke {
                 paint: Paint::Link("lg2".into()),
-                width: StrokeWidth::new(10.0),
+                width: StrokeWidth::new(100.0),
                 ..Stroke::default()
             }),
             rendering_mode: Default::default(),
@@ -73,6 +74,7 @@ fn main() {
         .unwrap(),
     ));
 
+    /*
     let layer = composition.create_layer().unwrap();
     layer
         .add_to_defs(NodeKind::LinearGradient(LinearGradient {
@@ -140,10 +142,11 @@ fn main() {
         "rect".to_string(),
         Linear::new(220, 290, (1250.0, 500.0).into(), (0.0, 0.0).into()).unwrap(),
     ));
+     */
 
     let out_path = PathBuf::from("out.mp4");
     let tmp_path = PathBuf::from("./out");
 
-    let mut renderer = FfmpegRenderer::new(out_path, tmp_path, FrameImageFormat::Bmp);
+    let mut renderer = FfmpegRenderer::new(out_path, tmp_path, FrameImageFormat::Png);
     renderer.render(composition).unwrap()
 }

--- a/rusvid_lib/Cargo.toml
+++ b/rusvid_lib/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.65"
 image = { version = "0.24", default-features = false, features = ["png", "bmp", "jpeg"] }
 easer = { git = "https://github.com/orhanbalci/rust-easing", rev = "872ea2c" }
 glam = { version = "0.21.3", features = ["approx"] }
+rusvid_plane = { path = "../crates/plane" }
 
 [dev-dependencies]
 rayon = "*"

--- a/rusvid_lib/Cargo.toml
+++ b/rusvid_lib/Cargo.toml
@@ -19,6 +19,7 @@ image = { version = "0.24", default-features = false, features = ["png", "bmp", 
 easer = { git = "https://github.com/orhanbalci/rust-easing", rev = "872ea2c" }
 glam = { version = "0.21.3", features = ["approx"] }
 rusvid_plane = { path = "../crates/plane" }
+itertools = "0.10.5"
 
 [dev-dependencies]
 rayon = "*"

--- a/rusvid_lib/src/animation/position_animation.rs
+++ b/rusvid_lib/src/animation/position_animation.rs
@@ -13,10 +13,10 @@ pub struct PositionAnimation {
 }
 
 impl PositionAnimation {
-    pub fn new<T: Function + 'static>(id: String, curve: T) -> Self {
+    pub fn new<T: Function + 'static>(id: impl Into<String>, curve: T) -> Self {
         PositionAnimation {
             curve: Box::new(curve),
-            object_id: id,
+            object_id: id.into(),
         }
     }
 }

--- a/rusvid_lib/src/composition/builder.rs
+++ b/rusvid_lib/src/composition/builder.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use usvg::{AspectRatio, Size, Svg, Tree, ViewBox};
 
 use crate::composition::Composition;
+
+use crate::effect::EffectLogic;
 use crate::layer::Layer;
 use crate::resolution::Resolution;
 use crate::types::FPS;
@@ -13,6 +15,7 @@ pub struct CompositionBuilder {
     duration: u16,
     name: String,
     layers: Vec<Layer>,
+    effects: Vec<Box<dyn EffectLogic>>,
 }
 
 impl Default for CompositionBuilder {
@@ -25,6 +28,7 @@ impl Default for CompositionBuilder {
             duration: 10,
             name: "UNKNOWN".to_string(),
             layers: Vec::new(),
+            effects: Vec::new(),
         }
     }
 }
@@ -50,6 +54,7 @@ impl CompositionBuilder {
             duration: self.duration,
             name: self.name,
             layers: self.layers,
+            effects: self.effects,
         }
     }
 
@@ -75,6 +80,11 @@ impl CompositionBuilder {
 
     pub fn add_layer(mut self, layer: Layer) -> Self {
         self.layers.push(layer);
+        self
+    }
+
+    pub fn add_effect<T: EffectLogic + 'static>(mut self, effect: T) -> Self {
+        self.effects.push(Box::new(effect));
         self
     }
 }

--- a/rusvid_lib/src/composition/builder.rs
+++ b/rusvid_lib/src/composition/builder.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use usvg::{AspectRatio, Size, Svg, Tree, ViewBox};
 
 use crate::composition::Composition;
-
 use crate::effect::EffectLogic;
 use crate::layer::Layer;
 use crate::resolution::Resolution;

--- a/rusvid_lib/src/composition/strukt.rs
+++ b/rusvid_lib/src/composition/strukt.rs
@@ -3,6 +3,7 @@ use usvg::{Fill, Node, NodeKind, Tree};
 
 use crate::animation::Animation;
 use crate::composition::CompositionBuilder;
+use crate::effect::EffectLogic;
 use crate::layer::{Layer, LayerLogic};
 use crate::metrics::{MetricsSize, MetricsVideo};
 use crate::resolution::Resolution;
@@ -22,6 +23,8 @@ pub struct Composition {
     pub name: String,
 
     pub(crate) layers: Vec<Layer>,
+
+    pub(crate) effects: Vec<Box<dyn EffectLogic>>,
 }
 
 impl Composition {

--- a/rusvid_lib/src/effect/library/color_palette.rs
+++ b/rusvid_lib/src/effect/library/color_palette.rs
@@ -34,12 +34,12 @@ impl Element for ColorPaletteEffect {
 }
 
 impl EffectLogic for ColorPaletteEffect {
-    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage> {
+    fn apply(&self, original: RgbaImage) -> Result<RgbaImage> {
         if self.color_palette.len() == 0 {
             bail!("Must have at least one color in the color palette");
         }
 
-        let mut result = original.clone();
+        let mut result = RgbaImage::new(original.width(), original.height());
 
         for x in 0..result.width() {
             for y in 0..result.height() {

--- a/rusvid_lib/src/effect/library/color_palette.rs
+++ b/rusvid_lib/src/effect/library/color_palette.rs
@@ -1,0 +1,58 @@
+use anyhow::{bail, Result};
+use image::{Rgba, RgbaImage};
+use rusvid_plane::Pixel;
+
+use crate::effect::EffectLogic;
+
+#[derive(Debug)]
+pub struct ColorPaletteEffect {
+    color_palette: Vec<Pixel>,
+}
+
+impl ColorPaletteEffect {
+    pub fn new(color_palette: Vec<Pixel>) -> Self {
+        ColorPaletteEffect { color_palette }
+    }
+}
+
+impl EffectLogic for ColorPaletteEffect {
+    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage> {
+        if self.color_palette.len() == 0 {
+            bail!("Must have at least one color in the color palette");
+        }
+
+        let mut result = original.clone();
+
+        for x in 0..result.width() {
+            for y in 0..result.height() {
+                let old_color = original.get_pixel(x, y);
+
+                let mut best_palette_color = self.color_palette[0];
+                let mut distance = u32::MAX;
+                for i in 0..self.color_palette.len() {
+                    let color_to_test = self.color_palette[i];
+                    let test_distance = old_color[0].abs_diff(color_to_test[0]) as u32
+                        + old_color[1].abs_diff(color_to_test[1]) as u32
+                        + old_color[2].abs_diff(color_to_test[2]) as u32
+                        + old_color[3].abs_diff(color_to_test[3]) as u32;
+
+                    if test_distance < distance {
+                        best_palette_color = color_to_test;
+                        distance = test_distance;
+                    }
+                }
+
+                let new_color = Rgba([
+                    best_palette_color[0],
+                    best_palette_color[1],
+                    best_palette_color[2],
+                    best_palette_color[3],
+                ]);
+
+                *result.get_pixel_mut(x, y) = new_color;
+            }
+        }
+
+        Ok(result)
+    }
+}

--- a/rusvid_lib/src/effect/library/color_palette.rs
+++ b/rusvid_lib/src/effect/library/color_palette.rs
@@ -2,16 +2,34 @@ use anyhow::{bail, Result};
 use image::{Rgba, RgbaImage};
 use rusvid_plane::Pixel;
 
-use crate::effect::EffectLogic;
+use crate::effect::{EffectLogic, Element, ID};
 
 #[derive(Debug)]
 pub struct ColorPaletteEffect {
     color_palette: Vec<Pixel>,
+
+    id: Option<String>,
 }
 
 impl ColorPaletteEffect {
     pub fn new(color_palette: Vec<Pixel>) -> Self {
-        ColorPaletteEffect { color_palette }
+        ColorPaletteEffect {
+            color_palette,
+            id: None,
+        }
+    }
+
+    pub fn new_with_id(color_palette: Vec<Pixel>, id: impl Into<ID>) -> Self {
+        let mut cpe = Self::new(color_palette);
+        cpe.id = Some(id.into());
+
+        cpe
+    }
+}
+
+impl Element for ColorPaletteEffect {
+    fn id(&self) -> Option<&ID> {
+        self.id.as_ref()
     }
 }
 

--- a/rusvid_lib/src/effect/library/grayscale.rs
+++ b/rusvid_lib/src/effect/library/grayscale.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use image::{Rgba, RgbaImage};
+
+use crate::effect::{EffectLogic, Element, ID};
+
+const MULTIPLIER_RED: f32 = 0.299;
+const MULTIPLIER_GREEN: f32 = 0.587;
+const MULTIPLIER_BLUE: f32 = 0.114;
+
+#[derive(Debug)]
+pub struct GrayscaleEffect {
+    id: Option<String>,
+}
+
+impl GrayscaleEffect {
+    pub fn new() -> Self {
+        GrayscaleEffect { id: None }
+    }
+
+    pub fn new_with_id(id: impl Into<String>) -> Self {
+        let mut effect = Self::new();
+        effect.id = Some(id.into());
+
+        effect
+    }
+}
+
+impl Element for GrayscaleEffect {
+    fn id(&self) -> Option<&ID> {
+        self.id.as_ref()
+    }
+}
+
+impl EffectLogic for GrayscaleEffect {
+    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage> {
+        let mut result = original.clone();
+
+        for x in 0..result.width() {
+            for y in 0..result.height() {
+                let original_color = original.get_pixel(x, y);
+
+                let grayscale_value = (original_color[0] as f32 * MULTIPLIER_RED
+                    + original_color[1] as f32 * MULTIPLIER_GREEN
+                    + original_color[2] as f32 * MULTIPLIER_BLUE)
+                    as u8;
+
+                *result.get_pixel_mut(x, y) = Rgba([
+                    grayscale_value,
+                    grayscale_value,
+                    grayscale_value,
+                    original_color[3],
+                ]);
+            }
+        }
+
+        Ok(result)
+    }
+}

--- a/rusvid_lib/src/effect/library/grayscale.rs
+++ b/rusvid_lib/src/effect/library/grayscale.rs
@@ -32,8 +32,8 @@ impl Element for GrayscaleEffect {
 }
 
 impl EffectLogic for GrayscaleEffect {
-    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage> {
-        let mut result = original.clone();
+    fn apply(&self, original: RgbaImage) -> Result<RgbaImage> {
+        let mut result = RgbaImage::new(original.width(), original.height());
 
         for x in 0..result.width() {
             for y in 0..result.height() {

--- a/rusvid_lib/src/effect/library/mod.rs
+++ b/rusvid_lib/src/effect/library/mod.rs
@@ -1,0 +1,3 @@
+mod color_palette;
+
+pub use color_palette::ColorPaletteEffect;

--- a/rusvid_lib/src/effect/library/mod.rs
+++ b/rusvid_lib/src/effect/library/mod.rs
@@ -1,5 +1,7 @@
 mod color_palette;
 mod grayscale;
+mod pixelate;
 
 pub use color_palette::ColorPaletteEffect;
 pub use grayscale::GrayscaleEffect;
+pub use pixelate::PixelateEffect;

--- a/rusvid_lib/src/effect/library/mod.rs
+++ b/rusvid_lib/src/effect/library/mod.rs
@@ -1,3 +1,5 @@
 mod color_palette;
+mod grayscale;
 
 pub use color_palette::ColorPaletteEffect;
+pub use grayscale::GrayscaleEffect;

--- a/rusvid_lib/src/effect/library/pixelate.rs
+++ b/rusvid_lib/src/effect/library/pixelate.rs
@@ -36,7 +36,7 @@ impl Element for PixelateEffect {
 }
 
 impl EffectLogic for PixelateEffect {
-    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage> {
+    fn apply(&self, original: RgbaImage) -> Result<RgbaImage> {
         // TODO create extra config if last pixel in a row should be not fixed size or if the extra margin should be applied to the last pixel, (width & height)
         // eg.: pixel_width = 19px; width = 1920px; pixel_width * width = 1919px, last pixel either 1px wide or last one is 20px wide
         let pixels_count_width = original.width().div_ceil(self.pixel_width);

--- a/rusvid_lib/src/effect/library/pixelate.rs
+++ b/rusvid_lib/src/effect/library/pixelate.rs
@@ -1,0 +1,90 @@
+use anyhow::Result;
+use image::{Rgba, RgbaImage};
+use itertools::Itertools;
+
+use crate::effect::{EffectLogic, Element, ID};
+
+#[derive(Debug)]
+pub struct PixelateEffect {
+    pixel_width: u32,
+    pixel_height: u32,
+
+    id: Option<String>,
+}
+
+impl PixelateEffect {
+    pub fn new(pixel_width: u32, pixel_height: u32) -> Self {
+        PixelateEffect {
+            pixel_width,
+            pixel_height,
+            id: None,
+        }
+    }
+
+    pub fn new_with_id(pixel_width: u32, pixel_height: u32, id: impl Into<String>) -> Self {
+        let mut effect = Self::new(pixel_width, pixel_height);
+        effect.id = Some(id.into());
+
+        effect
+    }
+}
+
+impl Element for PixelateEffect {
+    fn id(&self) -> Option<&ID> {
+        self.id.as_ref()
+    }
+}
+
+impl EffectLogic for PixelateEffect {
+    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage> {
+        // TODO create extra config if last pixel in a row should be not fixed size or if the extra margin should be applied to the last pixel, (width & height)
+        // eg.: pixel_width = 19px; width = 1920px; pixel_width * width = 1919px, last pixel either 1px wide or last one is 20px wide
+        let pixels_count_width = original.width().div_ceil(self.pixel_width);
+        let pixels_count_height = original.height().div_ceil(self.pixel_height);
+
+        let mut result = RgbaImage::new(original.width(), original.height());
+
+        for x in 0..pixels_count_width {
+            for y in 0..pixels_count_height {
+                let from_pixels_width = x * self.pixel_width;
+                let to_pixels_width = ((x + 1) * self.pixel_width).min(result.width());
+
+                let from_pixels_height = y * self.pixel_height;
+                let to_pixels_height = ((y + 1) * self.pixel_height).min(result.height());
+
+                let sum = (from_pixels_width..to_pixels_width)
+                    .cartesian_product(from_pixels_height..to_pixels_height)
+                    .map(|(i_x, i_y)| original.get_pixel(i_x, i_y).0)
+                    .fold([0_u64; 4], |acc, val| {
+                        let mut back_value = acc;
+
+                        back_value[0] += val[0] as u64;
+                        back_value[1] += val[1] as u64;
+                        back_value[2] += val[2] as u64;
+                        back_value[3] += val[3] as u64;
+
+                        back_value
+                    });
+
+                let summed_pixels = (((to_pixels_width + 1) - from_pixels_width)
+                    * ((to_pixels_height + 1) - from_pixels_height))
+                    as u64;
+
+                let new_color = Rgba([
+                    (sum[0] / summed_pixels) as u8,
+                    (sum[1] / summed_pixels) as u8,
+                    (sum[2] / summed_pixels) as u8,
+                    (sum[3] / summed_pixels) as u8,
+                ]);
+
+                for i_x in from_pixels_width..to_pixels_width {
+                    for i_y in from_pixels_height..to_pixels_height {
+                        result.put_pixel(i_x, i_y, new_color);
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}

--- a/rusvid_lib/src/effect/mod.rs
+++ b/rusvid_lib/src/effect/mod.rs
@@ -12,7 +12,7 @@ pub trait Element {
 
 pub trait EffectLogic: std::fmt::Debug + Element {
     // TODO switch to `Plane`
-    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage>;
+    fn apply(&self, original: RgbaImage) -> Result<RgbaImage>;
 
     fn depends_on_other_effects_ids(&self) -> Vec<ID> {
         Vec::new()

--- a/rusvid_lib/src/effect/mod.rs
+++ b/rusvid_lib/src/effect/mod.rs
@@ -31,5 +31,6 @@ pub trait EffectLogic: std::fmt::Debug + Element {
         self.depends_on_other_effects_ids().len() != 0
     }
 
+    #[allow(unused_variables)]
     fn add_depended_on_other_effect(&mut self, effect_id: &str) {}
 }

--- a/rusvid_lib/src/effect/mod.rs
+++ b/rusvid_lib/src/effect/mod.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use image::RgbaImage;
+
+pub mod library;
+
+pub trait EffectLogic: std::fmt::Debug {
+    // TODO switch to `Plane`
+    fn apply(self: &Self, original: &RgbaImage) -> Result<RgbaImage>;
+}

--- a/rusvid_lib/src/effect/mod.rs
+++ b/rusvid_lib/src/effect/mod.rs
@@ -3,7 +3,33 @@ use image::RgbaImage;
 
 pub mod library;
 
-pub trait EffectLogic: std::fmt::Debug {
+pub type ID = String;
+
+// TODO move into separate file and use in the whole project for objects which can hold an id
+pub trait Element {
+    fn id(&self) -> Option<&ID>;
+}
+
+pub trait EffectLogic: std::fmt::Debug + Element {
     // TODO switch to `Plane`
-    fn apply(self: &Self, original: &RgbaImage) -> Result<RgbaImage>;
+    fn apply(&self, original: &RgbaImage) -> Result<RgbaImage>;
+
+    fn depends_on_other_effects_ids(&self) -> Vec<ID> {
+        Vec::new()
+    }
+
+    /// Returns `true` if the effect depends on one (or more) other effects, otherwise the function returns `false`
+    ///
+    /// Example:
+    /// ```rust
+    /// use rusvid_lib::prelude::*;
+    ///
+    /// let effect = ColorPaletteEffect::new(vec![]);
+    /// assert!(!effect.depends_on_other_effects());
+    /// ```
+    fn depends_on_other_effects(&self) -> bool {
+        self.depends_on_other_effects_ids().len() != 0
+    }
+
+    fn add_depended_on_other_effect(&mut self, effect_id: &str) {}
 }

--- a/rusvid_lib/src/lib.rs
+++ b/rusvid_lib/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
     pub use crate::animation::curves::Function;
     pub use crate::composition::Composition;
     pub use crate::composition::CompositionBuilder;
-    pub use crate::effect::{library::*, EffectLogic};
+    pub use crate::effect::{library::*, EffectLogic, Element};
     pub use crate::layer::{Layer, LayerLogic};
     pub use crate::metrics::{MetricsSize, MetricsVideo};
     pub use crate::renderer::ffmpeg::FfmpegRenderer;

--- a/rusvid_lib/src/lib.rs
+++ b/rusvid_lib/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(get_mut_unchecked)]
+#![feature(int_roundings)]
 
 pub mod animation;
 pub mod composition;

--- a/rusvid_lib/src/lib.rs
+++ b/rusvid_lib/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod animation;
 pub mod composition;
+pub mod effect;
 pub mod figures;
 pub mod layer;
 pub mod metrics;
@@ -18,6 +19,7 @@ pub mod prelude {
     pub use crate::animation::curves::Function;
     pub use crate::composition::Composition;
     pub use crate::composition::CompositionBuilder;
+    pub use crate::effect::{library::*, EffectLogic};
     pub use crate::layer::{Layer, LayerLogic};
     pub use crate::metrics::{MetricsSize, MetricsVideo};
     pub use crate::renderer::ffmpeg::FfmpegRenderer;

--- a/rusvid_lib/src/renderer/ffmpeg/mod.rs
+++ b/rusvid_lib/src/renderer/ffmpeg/mod.rs
@@ -45,13 +45,13 @@ impl Default for FfmpegRenderer {
 
 impl FfmpegRenderer {
     pub fn new(
-        out_path: PathBuf,
-        tmp_dir_path: PathBuf,
+        out_path: impl Into<PathBuf>,
+        tmp_dir_path: impl Into<PathBuf>,
         frame_output_format: FrameImageFormat,
     ) -> Self {
         FfmpegRenderer {
-            out_path,
-            tmp_dir_path,
+            out_path: out_path.into(),
+            tmp_dir_path: tmp_dir_path.into(),
             frame_output_format,
             ..FfmpegRenderer::default()
         }

--- a/rusvid_lib/src/renderer/mod.rs
+++ b/rusvid_lib/src/renderer/mod.rs
@@ -126,6 +126,7 @@ pub trait Renderer {
         Ok(image)
     }
 
+    #[deprecated(since="0.1.2", note="use `render_plane` instead")]
     fn render_pixmap(&self, composition: &Composition) -> Result<Pixmap> {
         let image = self.render_rgba_image(&composition)?;
         let pixels = image.to_vec();

--- a/rusvid_lib/src/renderer/mod.rs
+++ b/rusvid_lib/src/renderer/mod.rs
@@ -126,7 +126,7 @@ pub trait Renderer {
         Ok(image)
     }
 
-    #[deprecated(since="0.1.2", note="use `render_plane` instead")]
+    #[deprecated(since = "0.1.2", note = "use `render_plane` instead")]
     fn render_pixmap(&self, composition: &Composition) -> Result<Pixmap> {
         let image = self.render_rgba_image(&composition)?;
         let pixels = image.to_vec();

--- a/rusvid_lib/src/resolution.rs
+++ b/rusvid_lib/src/resolution.rs
@@ -1,5 +1,6 @@
 use crate::{
     metrics::{MetricsSize, MetricsVideo},
+    prelude::AsPoint,
     types::Point,
 };
 
@@ -25,12 +26,6 @@ impl Resolution {
             Resolution::FourK => (4096, 2160),
             Resolution::Custom(w, h) => (*w, *h),
         }
-    }
-
-    #[inline]
-    pub fn as_point(&self) -> Point {
-        let (width, height) = self.value();
-        Point::new(width as f64, height as f64)
     }
 
     #[inline]
@@ -78,5 +73,12 @@ impl MetricsSize for Resolution {
 impl Default for Resolution {
     fn default() -> Self {
         Resolution::FHD
+    }
+}
+
+impl AsPoint for Resolution {
+    fn as_point(&self) -> Point {
+        let (width, height) = self.value();
+        Point::new(width as f64, height as f64)
     }
 }

--- a/rusvid_lib/src/resolution.rs
+++ b/rusvid_lib/src/resolution.rs
@@ -1,4 +1,7 @@
-use crate::metrics::{MetricsSize, MetricsVideo};
+use crate::{
+    metrics::{MetricsSize, MetricsVideo},
+    types::Point,
+};
 
 pub type ResolutionType = (usize, usize);
 
@@ -13,6 +16,7 @@ pub enum Resolution {
 }
 
 impl Resolution {
+    #[inline]
     pub fn value(&self) -> ResolutionType {
         match self {
             Resolution::HD => (1280, 720),
@@ -21,6 +25,12 @@ impl Resolution {
             Resolution::FourK => (4096, 2160),
             Resolution::Custom(w, h) => (*w, *h),
         }
+    }
+
+    #[inline]
+    pub fn as_point(&self) -> Point {
+        let (width, height) = self.value();
+        Point::new(width as f64, height as f64)
     }
 
     #[inline]

--- a/rusvid_lib/src/types.rs
+++ b/rusvid_lib/src/types.rs
@@ -2,3 +2,7 @@ use glam::DVec2;
 
 pub type FPS = u8;
 pub type Point = DVec2;
+
+pub trait AsPoint {
+    fn as_point(&self) -> Point;
+}

--- a/rusvid_lib/tests/animation.rs
+++ b/rusvid_lib/tests/animation.rs
@@ -33,7 +33,7 @@ fn renders_correctly_static() {
 
     // TODO why not with end_frame=1
     composition.add_animation(PositionAnimation::new(
-        "rect".to_string(),
+        "rect",
         Linear::new(0, 1, Point::ZERO, Point::new(50.0, 50.0)).unwrap(),
     ));
 


### PR DESCRIPTION
This branch was in the beginning only to implement an alternetive for `image::RgbaImage` and `tiny_skia::Pixmap` but I only implemented a small `Plane` struct for the future and the possibility for composition and (in the following commits) layer to hold effects. It's maybe also a good idea to add sth like `Filter`.

Effect:
- ability to change 'old' pixel values
- ability to change the resolution of the frame (smells like sth is `unsafe`!... but not from the rust code... more general)

Advancement:
- proc macro to transform a simple function with the signature `fn name(original &RgbaImage) -> RgbaImage` or `fn name(pixel: Pixel, x: u32, y: u32) -> Pixel` into a struct `NameEffect` that implements the `Effect + Element` trait.